### PR TITLE
feat: restore deepin patches on kmod

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+kmod (34.2-2deepin1) unstable; urgency=medium
+
+  * Restore uniontech-add-lseek-to-porting-pread.patch from master branch:
+    add lseek to verify fd seekability before using pread.
+
+ -- lichenggang <lichenggang@uniontech.com>  Thu, 17 Jul 2026 23:27:00 +0800
+
 kmod (34.2-2) unstable; urgency=medium
 
   * kmod.initramfs-hook: if compressed modules have been copied to the

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 da2654b
 fix_riscv64_tests
+uniontech-add-lseek-to-porting-pread.patch

--- a/debian/patches/uniontech-add-lseek-to-porting-pread.patch
+++ b/debian/patches/uniontech-add-lseek-to-porting-pread.patch
@@ -1,0 +1,21 @@
+Description: Add lseek to porting pread
+Author: dongshengyuan <dongshengyuan@uniontech.com>
+Origin: https://github.com/deepin-community/kmod.git
+Last-Update: 2025-11-25
+
+--- a/libkmod/libkmod-file.c	2026-07-17 23:26:29.977626899 +0800
++++ b/libkmod/libkmod-file.c	2026-07-17 23:26:29.987627101 +0800
+@@ -95,6 +95,13 @@
+ 		return NULL;
+ 	}
+ 
++	sz = lseek(file->fd, 0, SEEK_CUR);
++	if (sz < 0) {
++		close(file->fd);
++		free(file);
++		return NULL;
++	}
++
+ 	sz = pread_str_safe(file->fd, buf, sizeof(buf), 0);
+ 	if (sz != (sizeof(buf) - 1)) {
+ 		if (sz < 0)


### PR DESCRIPTION
Restore deepin-specific patches from master branch:
- uniontech pread patch

Related: automated backport of deepin patches.